### PR TITLE
17 Make stereo processing possible

### DIFF
--- a/Source/OJDProcessor.cpp
+++ b/Source/OJDProcessor.cpp
@@ -50,9 +50,8 @@ void OJDAudioProcessor::prepareResources (bool sampleRateChanged, bool maxBlockS
 {
     if (numChannelsChanged)
     {
-        jassert (getTotalNumOutputChannels() == numChannels);
-        jassert (getTotalNumInputChannels()  == numChannels);
-        return;
+        jassert (getTotalNumOutputChannels() == getTotalNumInputChannels());
+        numChannels = getTotalNumInputChannels();
     }
 
     juce::ignoreUnused (sampleRateChanged, maxBlockSizeChanged);
@@ -63,8 +62,8 @@ void OJDAudioProcessor::prepareResources (bool sampleRateChanged, bool maxBlockS
     recalculateFilters();
 
     // Some fixed coefficients
-    *chain.get<hpf30>()  .coefficients = *BiquadCoeffs::makeFirstOrderHighPass (spec.sampleRate, 30.0f);
-    *chain.get<lpf6_3k>().coefficients = *BiquadCoeffs::makeFirstOrderLowPass  (spec.sampleRate, 6.3e3f);
+    *chain.get<hpf30>()  .state = *BiquadCoeffs::makeFirstOrderHighPass (spec.sampleRate, 30.0f);
+    *chain.get<lpf6_3k>().state = *BiquadCoeffs::makeFirstOrderLowPass  (spec.sampleRate, 6.3e3f);
 
     // Computing the chains latency. The oversampling in the waveshaper might introduce fractional sample delay
     const auto waveshaperLatency = chain.get<waveshaper>().getLatencyInSamples();
@@ -74,8 +73,12 @@ void OJDAudioProcessor::prepareResources (bool sampleRateChanged, bool maxBlockS
 
 bool OJDAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
 {
-    auto mono = juce::AudioChannelSet::mono();
-    return layouts.getMainInputChannelSet() == mono && layouts.getMainOutputChannelSet() == mono;
+    auto mono   = juce::AudioChannelSet::mono();
+    auto stereo = juce::AudioChannelSet::stereo();
+
+    // We are supporting mono -> mono or stereo -> stereo setups
+    return (layouts.getMainInputChannelSet() == mono   && layouts.getMainOutputChannelSet() == mono) ||
+           (layouts.getMainInputChannelSet() == stereo && layouts.getMainOutputChannelSet() == stereo) ;
 }
 
 void OJDAudioProcessor::processBlock (juce::dsp::AudioBlock<float>& block)
@@ -119,11 +122,11 @@ void OJDAudioProcessor::updateParametersForProcessorChain()
     // Drive – coefficients are computed in the parameterChanged callback, therefore we need the lock
     if (biquadParametersUpdated.load() && biquadParameterLock.tryEnter())
     {
-        std::swap (chain.get<biquadPreDriveBoost>().coefficients,   biquadPreDriveBoostCoeffs);
-        std::swap (chain.get<biquadPreDriveNotch>().coefficients,   biquadPreDriveNotchCoeffs);
-        std::swap (chain.get<biquadPostDriveBoost1>().coefficients, biquadPostDriveBoost1Coeffs);
-        std::swap (chain.get<biquadPostDriveBoost2>().coefficients, biquadPostDriveBoost2Coeffs);
-        std::swap (chain.get<biquadPostDriveBoost3>().coefficients, biquadPostDriveBoost3Coeffs);
+        *chain.get<biquadPreDriveBoost>().state   = *biquadPreDriveBoostCoeffs;
+        *chain.get<biquadPreDriveNotch>().state   = *biquadPreDriveNotchCoeffs;
+        *chain.get<biquadPostDriveBoost1>().state = *biquadPostDriveBoost1Coeffs;
+        *chain.get<biquadPostDriveBoost2>().state = *biquadPostDriveBoost2Coeffs;
+        *chain.get<biquadPostDriveBoost3>().state = *biquadPostDriveBoost3Coeffs;
 
         biquadParametersUpdated.store (false);
         biquadParameterLock.exit();

--- a/Source/OJDProcessor.h
+++ b/Source/OJDProcessor.h
@@ -52,9 +52,9 @@ public:
      */
     std::unique_ptr<jb::MessageOfTheDay::InfoAndUpdate> getMessageOfTheDay (int timeoutMilliseconds);
 
-    /** This processor will only process one channel */
-    static const int numChannels = 1;
 private:
+    int numChannels = 1;
+
     // References to all raw parameter values
     const std::atomic<float>& rawValueDrive;
     const std::atomic<float>& rawValueTone;
@@ -77,9 +77,9 @@ private:
         volume
     };
 
-    using HPF    = juce::dsp::IIR::Filter<float>;
-    using LPF    = juce::dsp::IIR::Filter<float>;
-    using Biquad = juce::dsp::IIR::Filter<float>;
+    using HPF    = juce::dsp::ProcessorDuplicator<juce::dsp::IIR::Filter<float>, juce::dsp::IIR::Coefficients<float>>;
+    using LPF    = juce::dsp::ProcessorDuplicator<juce::dsp::IIR::Filter<float>, juce::dsp::IIR::Coefficients<float>>;
+    using Biquad = juce::dsp::ProcessorDuplicator<juce::dsp::IIR::Filter<float>, juce::dsp::IIR::Coefficients<float>>;
     using Gain   = juce::dsp::Gain<float>;
 
     juce::dsp::ProcessorChain<HPF, Biquad, Biquad, Gain, Waveshaper, Biquad, Biquad, Biquad, LPF, ToneStack, Gain> chain;

--- a/Source/Waveshaper.h
+++ b/Source/Waveshaper.h
@@ -54,29 +54,32 @@ public:
 
     void prepare (const juce::dsp::ProcessSpec& spec) override
     {
-        oversampler.initProcessing (spec.maximumBlockSize);
+        constexpr size_t oversamplingOrder = 4;
+        constexpr auto filterType = juce::dsp::Oversampling<float>::filterHalfBandPolyphaseIIR;
+
+        oversampler = std::make_unique<juce::dsp::Oversampling<float>> (spec.numChannels, oversamplingOrder, filterType);
+        oversampler->initProcessing (spec.maximumBlockSize);
     }
 
     void process (const juce::dsp::ProcessContextReplacing<float>& context) override
     {
         // First sample up...
-        auto oversampledBlock = oversampler.processSamplesUp (context.getInputBlock());
+        auto oversampledBlock = oversampler->processSamplesUp (context.getInputBlock());
         // Then process with the waveshaper...
         waveshaper.process (juce::dsp::ProcessContextReplacing<float> (oversampledBlock));
         // Finally sample back down
-        oversampler.processSamplesDown (context.getOutputBlock());
+        oversampler->processSamplesDown (context.getOutputBlock());
     }
 
-    void reset() override { oversampler.reset(); }
+    void reset() override { oversampler->reset(); }
 
-    float getLatencyInSamples() { return oversampler.getLatencyInSamples(); }
+    float getLatencyInSamples()
+    {
+        return oversampler == nullptr ? 0.0f : oversampler->getLatencyInSamples();
+    }
 
 private:
-    static const size_t numChannels = 1;
-    static const size_t oversamplingOrder = 4;
-    static const int    oversamplingFactor = 1 << oversamplingOrder;
-    static const auto filterType = juce::dsp::Oversampling<float>::filterHalfBandPolyphaseIIR;
 
-    juce::dsp::Oversampling<float> oversampler {numChannels, oversamplingOrder, filterType};
+    std::unique_ptr<juce::dsp::Oversampling<float>> oversampler;
     juce::dsp::WaveShaper<float> waveshaper;
 };


### PR DESCRIPTION
Stereo processing is now possible, but updating coefficients allocation free just got even harder with these changes. To solve this in a clean way, some modifications to the JUCE codebase are needed, therefore it will stay like this for now.